### PR TITLE
Adds custom base path for Spring Data REST API

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,6 @@ spring.application.name=cruddemo
 spring.datasource.url=jdbc:mysql://localhost:3306/employee_directory
 spring.datasource.username=springstudent
 spring.datasource.password=springstudent
+
+# Spring Data REST properties
+spring.data.rest.base-path=/magic-api


### PR DESCRIPTION
Configures a custom base path for the Spring Data REST API by setting `spring.data.rest.base-path` to `/magic-api`. This change provides a more descriptive and user-friendly API endpoint structure, improving clarity and organization.